### PR TITLE
Make sidebar links use dynamic base URL

### DIFF
--- a/components/sidebar.php
+++ b/components/sidebar.php
@@ -1,23 +1,27 @@
 <?php
 $role = $_SESSION['role'] ?? 'guest';
 
+// ✅ Make this dynamic
+$base_url = '/seat-reservation-system';
+
 $sidebars = [
-    'admin' => [
-        ["href" => "../components/dashboard.php", "icon" => "fas fa-home", "text" => "Dashboard"],
-        ["href" => "../admin/admin_manage_seat.php", "icon" => "fas fa-users-cog", "text" => "Manage Seats"],
-        ["href" => "../admin/admin_reserve.php", "icon" => "fas fa-calendar-check", "text" => "Reservations"],
-        ["href" => "reports.php", "icon" => "fas fa-chart-line", "text" => "Reports"],
-        ["href" => "logout.php", "icon" => "fas fa-sign-out-alt", "text" => "Logout"],  
-    ],
-    'intern' => [
-        ["href" => "dashboard.php", "icon" => "fas fa-home", "text" => "Dashboard"],
-        ["href" => "manage_tools.php", "icon" => "fas fa-tools", "text" => "Manage Tools"],
-        ["href" => "logout.php", "icon" => "fas fa-sign-out-alt", "text" => "Logout"],
-    ]
+  'admin' => [
+    ["href" => "$base_url/components/dashboard.php", "icon" => "fas fa-home", "text" => "Dashboard"],
+    ["href" => "$base_url/admin/admin_manage_seat.php", "icon" => "fas fa-users-cog", "text" => "Manage Seats"],
+    ["href" => "$base_url/admin/admin_reserve.php", "icon" => "fas fa-calendar-check", "text" => "Reservations"],
+    ["href" => "$base_url/reports.php", "icon" => "fas fa-chart-line", "text" => "Reports"],
+    ["href" => "$base_url/login.php", "icon" => "fas fa-sign-out-alt", "text" => "Logout"],
+  ],
+  'intern' => [
+    ["href" => "$base_url/dashboard.php", "icon" => "fas fa-home", "text" => "Dashboard"],
+    ["href" => "$base_url/manage_tools.php", "icon" => "fas fa-tools", "text" => "Manage Tools"],
+    ["href" => "$base_url/login.php", "icon" => "fas fa-sign-out-alt", "text" => "Logout"],
+  ],
 ];
 
 $links = $sidebars[$role] ?? [];
 ?>
+
 
 <!-- Toggle Button (Mobile Only) -->
 <button class="sidebar-toggle" id="sidebarToggle">


### PR DESCRIPTION
Updated sidebar link generation to use a dynamic $base_url variable, ensuring all sidebar links are correctly prefixed for different environments. Also changed the logout link to point to login.php for both admin and intern roles.